### PR TITLE
Update bridgeboard with path to logs as logs/seerrbridge.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,11 +350,11 @@ services:
       - ./.env:/app/.env
     environment:
       - SEERRBRIDGE_URL=http://seerrbridge:8777
-      - SEERRBRIDGE_LOG_PATH=/seerrbridge_data/seerbridge.log
+      - SEERRBRIDGE_LOG_PATH=/seerrbridge_data/logs/seerrbridge.log
     entrypoint: >
       sh -c "
         mkdir -p /app && 
-        ln -sf /seerrbridge_data/seerbridge.log /app/seerbridge.log &&
+        ln -sf /seerrbridge_data/seerrbridge.log /app/logs/seerrbridge.log &&
         ln -sf /seerrbridge_data/episode_discrepancies.json /app/episode_discrepancies.json &&
         npm start
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,11 @@ services:
       - ./.env:/app/.env
     environment:
       - SEERRBRIDGE_URL=http://seerrbridge:8777
-      - SEERRBRIDGE_LOG_PATH=/seerrbridge_data/seerbridge.log
+      - SEERRBRIDGE_LOG_PATH=/seerrbridge_data/logs/seerrbridge.log
     entrypoint: >
       sh -c "
         mkdir -p /app && 
-        ln -sf /seerrbridge_data/seerbridge.log /app/seerbridge.log &&
+        ln -sf /seerrbridge_data/seerrbridge.log /app/logs/seerrbridge.log &&
         ln -sf /seerrbridge_data/episode_discrepancies.json /app/episode_discrepancies.json &&
         npm start
       "

--- a/logs/log_baseline.json
+++ b/logs/log_baseline.json
@@ -1,5 +1,5 @@
 {
-  "seerbridge.log": {
+  "seerrbridge.log": {
     "size": 0,
     "lastModified": "2023-01-01T00:00:00.000Z",
     "lineCount": 0

--- a/seerrbridge.py
+++ b/seerrbridge.py
@@ -42,7 +42,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 # Configure loguru
 logger.remove()  # Remove default handler
-logger.add("seerbridge.log", rotation="500 MB", encoding='utf-8')  # Use utf-8 encoding for log file
+logger.add("seerrbridge.log", rotation="500 MB", encoding='utf-8')  # Use utf-8 encoding for log file
 logger.add(sys.stdout, colorize=True)  # Ensure stdout can handle Unicode
 logger.level("WARNING", color="<cyan>")
 

--- a/src/app/api/debug/process-seerbridge-log/route.ts
+++ b/src/app/api/debug/process-seerbridge-log/route.ts
@@ -23,12 +23,12 @@ export async function GET(request: NextRequest) {
   try {
     const appRoot = process.cwd();
     const logsDir = path.join(appRoot, 'logs');
-    const seerrbridgeLogPath = path.join(logsDir, 'seerbridge.log');
+    const seerrbridgeLogPath = path.join(logsDir, 'seerrbridge.log');
     
     // Check if the file exists
     if (!fs.existsSync(seerrbridgeLogPath)) {
       return NextResponse.json({
-        error: "seerbridge.log file not found",
+        error: "seerrbridge.log file not found",
         logDir: logsDir,
         files: fs.existsSync(logsDir) ? fs.readdirSync(logsDir) : []
       }, { status: 404 });

--- a/src/app/api/debug/seerbridge-logs/route.ts
+++ b/src/app/api/debug/seerbridge-logs/route.ts
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest) {
   try {
     const appRoot = process.cwd();
     const logsDir = path.join(appRoot, 'logs');
-    const logFilePath = path.join(logsDir, 'seerbridge.log');
+    const logFilePath = path.join(logsDir, 'seerrbridge.log');
     
     // Check if directory and file exist
     const results = {

--- a/src/app/api/logs/critical/route.ts
+++ b/src/app/api/logs/critical/route.ts
@@ -37,7 +37,7 @@ interface LogConfiguration {
 }
 
 // Define the path to the log file in the root directory
-const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "seerbridge.log");
+const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "logs", "seerrbridge.log");
 
 // Define the path to the configuration file
 const CONFIG_FILE_PATH = path.join(process.cwd(), "logs", "log_config.json");

--- a/src/app/api/logs/entries/route.ts
+++ b/src/app/api/logs/entries/route.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { parseLogLines } from "@/lib/utils";
 
 // Define the path to the actual log file in the root directory
-const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "seerbridge.log");
+const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "logs", "seerrbridge.log");
 
 // Define the path to the configuration file
 const CONFIG_FILE_PATH = path.join(process.cwd(), "logs", "log_config.json");

--- a/src/app/api/logs/errors/route.ts
+++ b/src/app/api/logs/errors/route.ts
@@ -30,7 +30,7 @@ interface LogConfiguration {
 }
 
 // Define the path to the log file in the root directory
-const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "seerbridge.log");
+const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "logs", "seerrbridge.log");
 
 // Define the path to the configuration file
 const CONFIG_FILE_PATH = path.join(process.cwd(), "logs", "log_config.json");

--- a/src/app/api/logs/failures/route.ts
+++ b/src/app/api/logs/failures/route.ts
@@ -30,7 +30,7 @@ interface LogConfiguration {
 }
 
 // Define the path to the log file in the root directory
-const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "seerbridge.log");
+const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "logs", "seerrbridge.log");
 
 // Define the path to the configuration file
 const CONFIG_FILE_PATH = path.join(process.cwd(), "logs", "log_config.json");

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -37,7 +37,7 @@ interface LogConfiguration {
 }
 
 // Define the path to the log file in the root directory
-const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "seerbridge.log");
+const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "logs", "seerrbridge.log");
 
 // Define the path to the configuration file
 const CONFIG_FILE_PATH = path.join(process.cwd(), "logs", "log_config.json");
@@ -144,7 +144,7 @@ export async function GET(request: NextRequest) {
     }
     
     // Set the log file path relative to the application root
-    const logFilePath = path.join(process.cwd(), "seerbridge.log");
+    const logFilePath = path.join(process.cwd(), "seerrbridge.log");
     
     // Check if the file exists
     if (!fs.existsSync(logFilePath)) {

--- a/src/app/api/logs/stats/matches/route.ts
+++ b/src/app/api/logs/stats/matches/route.ts
@@ -45,7 +45,7 @@ async function loadLogConfig() {
 // Read log entries from the file system
 async function readLogEntries() {
   try {
-    const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "seerbridge.log");
+    const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "logs", "seerrbridge.log");
     
     // Check if log file exists in root directory
     if (!fs.existsSync(ROOT_LOG_FILE_PATH)) {

--- a/src/app/api/logs/success/route.ts
+++ b/src/app/api/logs/success/route.ts
@@ -30,7 +30,7 @@ interface LogConfiguration {
 }
 
 // Define the path to the log file in the root directory
-const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "seerbridge.log");
+const ROOT_LOG_FILE_PATH = path.join(process.cwd(), "logs", "seerrbridge.log");
 
 // Define the path to the configuration file
 const CONFIG_FILE_PATH = path.join(process.cwd(), "logs", "log_config.json");

--- a/src/app/api/notifications/background/route.ts
+++ b/src/app/api/notifications/background/route.ts
@@ -230,12 +230,12 @@ function getLogFiles(): string[] {
     
     // Create sample .log file if none exist (for initialization)
     if (logFiles.length === 0) {
-      const seerBridgeLogInLogs = path.join(LOGS_DIR, 'seerbridge.log');
-      const seerBridgeLogInRoot = path.join(APP_ROOT, 'seerbridge.log');
+      const seerBridgeLogInLogs = path.join(LOGS_DIR, 'seerrbridge.log');
+      const seerBridgeLogInRoot = path.join(APP_ROOT, 'seerrbridge.log');
       
       // Check if the log file exists in logs directory
       if (fs.existsSync(seerBridgeLogInLogs)) {
-        console.log(`[DEBUG] Found seerbridge.log file in logs directory`);
+        console.log(`[DEBUG] Found seerrbridge.log file in logs directory`);
         logFiles.push(seerBridgeLogInLogs);
       } 
       // If not in logs directory, check app root


### PR DESCRIPTION
This PR:

1. Corrects the name of the seerrbridge logfile (`seerrbridge.log` instead of `seerbridge.log`)
2. Updates bridgeboard to expect to find `seerrbridge.log` in a `logs/` subdirectory (*this was half-done already, from what I can tell*)

The utility - some users (like ElfHosted) prefer to keep their app files isolated from their user data - in this case, keeping the `seerrbridge.log` file in the `logs` directory aligns with the other files used by bridgeboard, and maintains consistency and separation.